### PR TITLE
Ansible流すサーバもふわっと管理する

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -6,3 +6,6 @@ dns:
 
 bastion:
 	ansible-playbook -i hosts ./services/bastion.yaml --vault-password-file ./vault_pass
+
+ansible:
+	ansible-playbook -i hosts ./services/ansible.yaml --vault-password-file ./vault_pass

--- a/ansible/roles/ansible/tasks/main.yaml
+++ b/ansible/roles/ansible/tasks/main.yaml
@@ -1,0 +1,5 @@
+- name: 'ansibleをインストール'
+  become: true
+  community.general.pacman:
+    name: ansible
+    state: latest

--- a/ansible/services/ansible.yaml
+++ b/ansible/services/ansible.yaml
@@ -1,0 +1,4 @@
+---
+- hosts: ansible
+  roles:
+    - ansible


### PR DESCRIPTION
これansibleって名前じゃなくてdeployerって名前にしておいたらterraform入れるときも便利だったよね