### PR TITLE
ssh設定の更新

### DIFF
--- a/ansible/hosts
+++ b/ansible/hosts
@@ -59,7 +59,6 @@ ansible_user=maintainer
 192.168.30.12
 192.168.30.20
 192.168.30.53
-192.168.30.54
 
 [archlinux:children]
 arch

--- a/ansible/roles/ssh/tasks/main.yaml
+++ b/ansible/roles/ssh/tasks/main.yaml
@@ -24,7 +24,7 @@
     host: '{{ item.name }}'
     hostname: '{{ item.address }}'
     forward_agent: true
-    strict_host_key_checking: 'yes'
+    strict_host_key_checking: 'no'
     state: present
   with_items: '{{ servers }}'
 


### PR DESCRIPTION
- ライブマイグレーションとかでめんどうなので `StrictHostKeyChecking` を外す
- rpi2退役